### PR TITLE
[P0] Design and implement Supabase schema

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,23 @@
+# Supabase configuration
+# Project URL: https://kkmyokfipaavjmlebjgq.supabase.co
+# project_id = "kkmyokfipaavjmlebjgq"
+
+[api]
+# Port to use for the local Supabase API server
+port = 54321
+
+[db]
+# Port to use for the local database server
+port = 54322
+
+[studio]
+# Port to use for Supabase Studio
+port = 54323
+
+[inbucket]
+# Port to use for the local email testing server
+port = 54324
+
+[auth]
+# The base URL of your website — used for redirects
+site_url = "http://localhost:3000"

--- a/supabase/migrations/20260331000000_initial_schema.sql
+++ b/supabase/migrations/20260331000000_initial_schema.sql
@@ -1,0 +1,165 @@
+-- Anonymity enforced: responses.staff_id does not exist. Department context derived from participation_token server-side.
+
+-- Enable UUID extension
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ============================================================
+-- departments
+-- ============================================================
+CREATE TABLE departments (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        text NOT NULL,
+  parent_id   uuid REFERENCES departments(id) ON DELETE SET NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_departments_parent_id ON departments(parent_id);
+
+-- ============================================================
+-- staff
+-- ============================================================
+CREATE TABLE staff (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name           text NOT NULL,
+  email          text UNIQUE NOT NULL,
+  department_id  uuid NOT NULL REFERENCES departments(id) ON DELETE RESTRICT,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_staff_department_id ON staff(department_id);
+CREATE INDEX idx_staff_email ON staff(email);
+
+-- ============================================================
+-- surveys
+-- ============================================================
+CREATE TABLE surveys (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title       text NOT NULL,
+  status      text NOT NULL DEFAULT 'draft'
+                CHECK (status IN ('draft', 'active', 'closed')),
+  open_date   date,
+  close_date  date,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_surveys_status ON surveys(status);
+
+-- ============================================================
+-- questions
+-- ============================================================
+CREATE TABLE questions (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  survey_id    uuid NOT NULL REFERENCES surveys(id) ON DELETE CASCADE,
+  type         text NOT NULL
+                 CHECK (type IN ('likert', 'free_text', 'multiple_choice')),
+  text         text NOT NULL,
+  order_index  int NOT NULL,
+  options      jsonb,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_questions_survey_id ON questions(survey_id);
+CREATE INDEX idx_questions_survey_order ON questions(survey_id, order_index);
+
+-- ============================================================
+-- responses  — NO staff_id column: anonymity enforced at schema level
+-- ============================================================
+CREATE TABLE responses (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  survey_id      uuid NOT NULL REFERENCES surveys(id) ON DELETE CASCADE,
+  question_id    uuid NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
+  answer         text NOT NULL,
+  department_id  uuid NOT NULL REFERENCES departments(id) ON DELETE RESTRICT,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_responses_survey_id      ON responses(survey_id);
+CREATE INDEX idx_responses_question_id    ON responses(question_id);
+CREATE INDEX idx_responses_department_id  ON responses(department_id);
+
+-- ============================================================
+-- participation_tokens
+-- ============================================================
+CREATE TABLE participation_tokens (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  staff_id    uuid NOT NULL REFERENCES staff(id) ON DELETE CASCADE,
+  survey_id   uuid NOT NULL REFERENCES surveys(id) ON DELETE CASCADE,
+  token       text UNIQUE NOT NULL,
+  used_at     timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (staff_id, survey_id)
+);
+
+CREATE INDEX idx_participation_tokens_token     ON participation_tokens(token);
+CREATE INDEX idx_participation_tokens_staff_id  ON participation_tokens(staff_id);
+CREATE INDEX idx_participation_tokens_survey_id ON participation_tokens(survey_id);
+
+-- ============================================================
+-- Row-Level Security
+-- ============================================================
+ALTER TABLE departments          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE staff                ENABLE ROW LEVEL SECURITY;
+ALTER TABLE surveys              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE questions            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE responses            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE participation_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Deny all anon/authenticated access by default; server-side service role bypasses RLS.
+-- Responses: explicitly no policy allows reading by staff_id (column doesn't exist).
+-- Admin operations use service_role key which bypasses RLS.
+
+-- Allow service_role full access (implicit — service_role bypasses RLS)
+-- Block direct table access to responses for non-service roles
+CREATE POLICY "no_direct_response_access" ON responses
+  AS RESTRICTIVE
+  FOR ALL
+  TO public
+  USING (false);
+
+-- Participation tokens: staff can only read their own token via server-side lookup
+CREATE POLICY "service_role_only_participation_tokens" ON participation_tokens
+  AS RESTRICTIVE
+  FOR ALL
+  TO public
+  USING (false);
+
+-- Staff table: no direct client access
+CREATE POLICY "service_role_only_staff" ON staff
+  AS RESTRICTIVE
+  FOR ALL
+  TO public
+  USING (false);
+
+-- Departments: readable by authenticated users (no sensitive data)
+CREATE POLICY "authenticated_read_departments" ON departments
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Surveys: readable by authenticated users
+CREATE POLICY "authenticated_read_surveys" ON surveys
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Questions: readable by authenticated users
+CREATE POLICY "authenticated_read_questions" ON questions
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- ============================================================
+-- Updated_at trigger for surveys
+-- ============================================================
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER surveys_updated_at
+  BEFORE UPDATE ON surveys
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Summary

Implements the full Supabase database schema for the Ausmed Engagement Survey Platform.

Closes #1

## Changes

- `supabase/migrations/20260331000000_initial_schema.sql` — full schema with all 6 tables
- `supabase/config.toml` — Supabase project configuration placeholder

## Schema Details

### Tables
- `departments` — supports nested hierarchy via self-referencing `parent_id`
- `staff` — employees with department assignment
- `surveys` — survey lifecycle with status (`draft`/`active`/`closed`)
- `questions` — per-survey questions supporting `likert`, `free_text`, `multiple_choice` types with JSONB options
- `responses` — **NO `staff_id` column** — anonymity enforced at schema level; department context comes from participation token server-side
- `participation_tokens` — one-per-staff-per-survey enforcement via UNIQUE(staff_id, survey_id)

### Security
- Row-Level Security enabled on all tables
- Restrictive RLS policies block direct client access to `responses`, `participation_tokens`, and `staff`
- Service role key bypasses RLS for server-side operations
- `departments`, `surveys`, `questions` readable by authenticated users

### Indexing
- All FK columns indexed
- `participation_tokens.token` indexed for fast lookup
- `questions` composite index on `(survey_id, order_index)`

## Acceptance Criteria
- [x] Schema in `supabase/migrations/` directory
- [x] No `staff_id` in `responses` table
- [x] UNIQUE constraint on `(staff_id, survey_id)` in `participation_tokens`
- [x] All FK columns indexed
- [x] RLS enabled on all tables