### PR TITLE
[P0] Implement Row-Level Security (RLS) policies

### DIFF
--- a/supabase/migrations/20260331010000_rls_policies.sql
+++ b/supabase/migrations/20260331010000_rls_policies.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- Migration: RLS policies for anonymity and access control
+-- Issue #2: Implement Row-Level Security (RLS) policies
+-- ============================================================
+
+-- ============================================================
+-- Drop the broad deny-all policies from initial schema
+-- These will be replaced by more granular policies below.
+-- ============================================================
+DROP POLICY IF EXISTS "no_direct_response_access" ON responses;
+DROP POLICY IF EXISTS "service_role_only_participation_tokens" ON participation_tokens;
+DROP POLICY IF EXISTS "service_role_only_staff" ON staff;
+DROP POLICY IF EXISTS "authenticated_read_departments" ON departments;
+DROP POLICY IF EXISTS "authenticated_read_surveys" ON surveys;
+DROP POLICY IF EXISTS "authenticated_read_questions" ON questions;
+
+-- ============================================================
+-- Helper function: validate a participation token for INSERT
+-- Returns true if the token exists, has not been used,
+-- and the survey is currently active.
+-- This function runs as the INVOKER (no privilege escalation).
+-- ============================================================
+CREATE OR REPLACE FUNCTION is_valid_unused_token(p_token text, p_survey_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM participation_tokens pt
+    JOIN surveys s ON s.id = pt.survey_id
+    WHERE pt.token = p_token
+      AND pt.survey_id = p_survey_id
+      AND pt.used_at IS NULL
+      AND s.status = 'active'
+      AND (s.opens_at IS NULL OR s.opens_at <= now())
+      AND (s.closes_at IS NULL OR s.closes_at >= now())
+  );
+$$;
+
+-- Grant execute to anon/authenticated so the policy can call it
+GRANT EXECUTE ON FUNCTION is_valid_unused_token(text, uuid) TO anon, authenticated;
+
+-- ============================================================
+-- RESPONSES table
+-- ============================================================
+
+-- No SELECT for anon or authenticated (service_role bypasses RLS)
+-- Already blocked by having no SELECT policy (deny-by-default when RLS is on)
+
+-- INSERT: only allowed when a valid, unused token exists for this survey
+-- The token is passed in the response row's 'survey_id' context.
+-- Actual token matching is handled at the application layer via service_role,
+-- but we add a DB-level guard using a session variable set by the API route.
+-- The API route sets: SET LOCAL app.submission_token = '<token>';
+CREATE POLICY "responses_insert_with_valid_token" ON responses
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (
+    is_valid_unused_token(
+      current_setting('app.submission_token', true),
+      survey_id
+    )
+  );
+
+-- ============================================================
+-- PARTICIPATION_TOKENS table
+-- ============================================================
+
+-- Anon users can SELECT their own token row (by token value) so the
+-- validate endpoint can confirm token existence and survey linkage.
+-- No other rows are visible (the WHERE clause acts as a filter).
+CREATE POLICY "tokens_select_own" ON participation_tokens
+  FOR SELECT
+  TO anon, authenticated
+  USING (token = current_setting('app.submission_token', true));
+
+-- INSERT/UPDATE/DELETE: service_role only (bypasses RLS automatically)
+-- Deny all other mutations from public roles
+CREATE POLICY "tokens_no_public_write" ON participation_tokens
+  AS RESTRICTIVE
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (false);
+
+CREATE POLICY "tokens_no_public_update" ON participation_tokens
+  AS RESTRICTIVE
+  FOR UPDATE
+  TO anon, authenticated
+  USING (false);
+
+CREATE POLICY "tokens_no_public_delete" ON participation_tokens
+  AS RESTRICTIVE
+  FOR DELETE
+  TO anon, authenticated
+  USING (false);
+
+-- ============================================================
+-- STAFF table
+-- ============================================================
+
+-- No access for public roles — staff data is sensitive PII.
+-- All staff queries go through service_role (bypasses RLS).
+CREATE POLICY "staff_no_public_access" ON staff
+  AS RESTRICTIVE
+  FOR ALL
+  TO anon, authenticated
+  USING (false);
+
+-- ============================================================
+-- DEPARTMENTS table
+-- ============================================================
+
+-- Authenticated admins can read department list (for UI selectors)
+CREATE POLICY "departments_authenticated_read" ON departments
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Anon cannot read departments (no department info needed in survey flow)
+CREATE POLICY "departments_no_anon_access" ON departments
+  AS RESTRICTIVE
+  FOR ALL
+  TO anon
+  USING (false);
+
+-- ============================================================
+-- SURVEYS table
+-- ============================================================
+
+-- Authenticated (admin) can read all surveys
+CREATE POLICY "surveys_authenticated_read" ON surveys
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Anon can only read the survey linked to their valid token
+-- (used in the survey completion flow to fetch survey details)
+CREATE POLICY "surveys_anon_read_by_token" ON surveys
+  FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM participation_tokens pt
+      WHERE pt.survey_id = surveys.id
+        AND pt.token = current_setting('app.submission_token', true)
+        AND pt.used_at IS NULL
+    )
+  );
+
+-- ============================================================
+-- QUESTIONS table
+-- ============================================================
+
+-- Authenticated (admin) can read all questions
+CREATE POLICY "questions_authenticated_read" ON questions
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Anon can only read questions for a survey they have a valid token for
+CREATE POLICY "questions_anon_read_by_token" ON questions
+  FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM participation_tokens pt
+      WHERE pt.survey_id = questions.survey_id
+        AND pt.token = current_setting('app.submission_token', true)
+        AND pt.used_at IS NULL
+    )
+  );
+
+-- ============================================================
+-- Comment: Single-use token enforcement
+-- When a response is submitted, the API route (using service_role) atomically:
+--   1. Inserts all response rows
+--   2. Sets participation_tokens.used_at = now() WHERE token = <token>
+-- The DB-level guard (is_valid_unused_token) ensures that even if the
+-- application layer is bypassed, a used token cannot produce a second INSERT.
+-- ============================================================


### PR DESCRIPTION
## Summary

Implements granular RLS policies for anonymity enforcement and token-based access control.

Closes #2

## Changes

New migration: `supabase/migrations/20260331010000_rls_policies.sql`

### Policy Breakdown

| Table | anon | authenticated | service_role |
|-------|------|---------------|---------------|
| `responses` | INSERT with valid token only | INSERT with valid token only | Full access |
| `participation_tokens` | SELECT own token only; no writes | SELECT own token only; no writes | Full access |
| `staff` | No access | No access | Full access |
| `departments` | No access | SELECT all | Full access |
| `surveys` | SELECT by valid token only | SELECT all | Full access |
| `questions` | SELECT by valid token only | SELECT all | Full access |

### Key Design Decisions

- **`app.submission_token` session variable**: API routes set `SET LOCAL app.submission_token = '<token>'` before queries. DB policies use `current_setting('app.submission_token', true)` to scope access per-request without storing the token in the data itself.
- **`is_valid_unused_token()` helper**: A SQL function that validates a token exists, is unused, and the linked survey is active. Used in the `responses` INSERT policy as a DB-level guard.
- **Single-use enforcement**: Even if the application layer is bypassed, a used token (`used_at IS NOT NULL`) cannot produce a second INSERT into `responses`.
- **No `staff_id` in `responses`**: Responses table has no identifier linking to staff — anonymity is structural, not just policy-based.

## Testing

Policies should be verified in Supabase dashboard policy tester or via psql:
- Anon with valid token: can SELECT survey/questions, can INSERT response
- Anon with used token: cannot INSERT response (policy rejects)
- Anon without token: cannot read surveys, questions, or responses
- Authenticated: can read all surveys/questions/departments; cannot read staff
- service_role: full access to all tables (bypasses RLS)
