### PR TITLE
[P1] Question CRUD API routes

### DIFF
--- a/app/api/questions/[id]/route.ts
+++ b/app/api/questions/[id]/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { requireAdmin, unauthorizedResponse } from '@/lib/supabase/auth'
+import type { QuestionType } from '@/lib/types/survey'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+interface UpdateQuestionBody {
+  type?: QuestionType
+  text?: string
+  order?: number
+  required?: boolean
+  options?: string[]
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    await requireAdmin()
+  } catch {
+    return unauthorizedResponse()
+  }
+
+  const { id: questionId } = await params
+
+  let body: Partial<UpdateQuestionBody>
+  try {
+    body = (await request.json()) as Partial<UpdateQuestionBody>
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+
+  // Fetch the question to verify it exists and get its survey
+  const { data: question, error: fetchError } = await supabase
+    .from('questions')
+    .select('id, survey_id, type')
+    .eq('id', questionId)
+    .single()
+
+  if (fetchError || !question) {
+    return NextResponse.json({ error: 'Question not found' }, { status: 404 })
+  }
+
+  // Verify the survey is not active/closed
+  const { data: survey, error: surveyError } = await supabase
+    .from('surveys')
+    .select('id, status')
+    .eq('id', question.survey_id)
+    .single()
+
+  if (surveyError || !survey) {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+
+  if (survey.status === 'active' || survey.status === 'closed') {
+    return NextResponse.json(
+      { error: 'Cannot modify questions on an active or closed survey' },
+      { status: 409 }
+    )
+  }
+
+  // Build updates object
+  const updates: Record<string, unknown> = {}
+
+  if (body.type !== undefined) {
+    if (!['likert', 'free_text', 'multiple_choice'].includes(body.type)) {
+      return NextResponse.json(
+        { error: 'type must be one of: likert, free_text, multiple_choice' },
+        { status: 400 }
+      )
+    }
+    updates.type = body.type
+  }
+
+  if (body.text !== undefined) {
+    if (typeof body.text !== 'string' || body.text.trim() === '') {
+      return NextResponse.json({ error: 'text must be a non-empty string' }, { status: 400 })
+    }
+    updates.text = body.text.trim()
+  }
+
+  if (body.order !== undefined) {
+    updates.order_index = body.order
+  }
+
+  if (body.required !== undefined) {
+    updates.required = body.required
+  }
+
+  const effectiveType = (body.type ?? question.type) as QuestionType
+  if (body.options !== undefined) {
+    if (effectiveType !== 'multiple_choice') {
+      return NextResponse.json(
+        { error: 'options can only be set on multiple_choice questions' },
+        { status: 400 }
+      )
+    }
+    if (!Array.isArray(body.options) || body.options.length < 2) {
+      return NextResponse.json(
+        { error: 'multiple_choice questions require at least 2 options' },
+        { status: 400 }
+      )
+    }
+    updates.options = body.options
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('questions')
+    .update(updates)
+    .eq('id', questionId)
+    .select('id, survey_id, type, text, options, order_index, required, created_at')
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  try {
+    await requireAdmin()
+  } catch {
+    return unauthorizedResponse()
+  }
+
+  const { id: questionId } = await params
+
+  const supabase = await createClient()
+
+  // Fetch the question to verify it exists and get its survey
+  const { data: question, error: fetchError } = await supabase
+    .from('questions')
+    .select('id, survey_id')
+    .eq('id', questionId)
+    .single()
+
+  if (fetchError || !question) {
+    return NextResponse.json({ error: 'Question not found' }, { status: 404 })
+  }
+
+  // Verify the survey is not active/closed
+  const { data: survey, error: surveyError } = await supabase
+    .from('surveys')
+    .select('id, status')
+    .eq('id', question.survey_id)
+    .single()
+
+  if (surveyError || !survey) {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+
+  if (survey.status === 'active' || survey.status === 'closed') {
+    return NextResponse.json(
+      { error: 'Cannot modify questions on an active or closed survey' },
+      { status: 409 }
+    )
+  }
+
+  const { error: deleteError } = await supabase
+    .from('questions')
+    .delete()
+    .eq('id', questionId)
+
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 })
+  }
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/surveys/[id]/questions/reorder/route.ts
+++ b/app/api/surveys/[id]/questions/reorder/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { requireAdmin, unauthorizedResponse } from '@/lib/supabase/auth'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+interface ReorderBody {
+  questionIds: string[]
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  try {
+    await requireAdmin()
+  } catch {
+    return unauthorizedResponse()
+  }
+
+  const { id: surveyId } = await params
+
+  let body: Partial<ReorderBody>
+  try {
+    body = (await request.json()) as Partial<ReorderBody>
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { questionIds } = body
+
+  if (!Array.isArray(questionIds) || questionIds.length === 0) {
+    return NextResponse.json({ error: 'questionIds must be a non-empty array' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+
+  // Check survey exists and is not active/closed
+  const { data: survey, error: surveyError } = await supabase
+    .from('surveys')
+    .select('id, status')
+    .eq('id', surveyId)
+    .single()
+
+  if (surveyError || !survey) {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+
+  if (survey.status === 'active' || survey.status === 'closed') {
+    return NextResponse.json(
+      { error: 'Cannot modify questions on an active or closed survey' },
+      { status: 409 }
+    )
+  }
+
+  // Update order_index for each question ID (index = order position)
+  const updates = questionIds.map((questionId, index) =>
+    supabase
+      .from('questions')
+      .update({ order_index: index })
+      .eq('id', questionId)
+      .eq('survey_id', surveyId)
+  )
+
+  const results = await Promise.all(updates)
+  for (const { error } of results) {
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+  }
+
+  return NextResponse.json({ reordered: questionIds.length })
+}

--- a/app/api/surveys/[id]/questions/route.ts
+++ b/app/api/surveys/[id]/questions/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { requireAdmin, unauthorizedResponse } from '@/lib/supabase/auth'
+import type { QuestionType } from '@/lib/types/survey'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+interface CreateQuestionBody {
+  type: QuestionType
+  text: string
+  order?: number
+  required?: boolean
+  options?: string[]
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    await requireAdmin()
+  } catch {
+    return unauthorizedResponse()
+  }
+
+  const { id: surveyId } = await params
+
+  let body: Partial<CreateQuestionBody>
+  try {
+    body = (await request.json()) as Partial<CreateQuestionBody>
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { type, text, order, required, options } = body
+
+  if (!type || !['likert', 'free_text', 'multiple_choice'].includes(type)) {
+    return NextResponse.json(
+      { error: 'type must be one of: likert, free_text, multiple_choice' },
+      { status: 400 }
+    )
+  }
+  if (!text || typeof text !== 'string' || text.trim() === '') {
+    return NextResponse.json({ error: 'text is required' }, { status: 400 })
+  }
+  if (type === 'multiple_choice') {
+    if (!Array.isArray(options) || options.length < 2) {
+      return NextResponse.json(
+        { error: 'multiple_choice questions require at least 2 options' },
+        { status: 400 }
+      )
+    }
+  }
+
+  const supabase = await createClient()
+
+  // Check survey exists and is not active/closed
+  const { data: survey, error: surveyError } = await supabase
+    .from('surveys')
+    .select('id, status')
+    .eq('id', surveyId)
+    .single()
+
+  if (surveyError || !survey) {
+    return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+  }
+
+  if (survey.status === 'active' || survey.status === 'closed') {
+    return NextResponse.json(
+      { error: 'Cannot modify questions on an active or closed survey' },
+      { status: 409 }
+    )
+  }
+
+  // Determine order_index: if not provided, append at end
+  let orderIndex = order ?? 0
+  if (order === undefined) {
+    const { count } = await supabase
+      .from('questions')
+      .select('id', { count: 'exact', head: true })
+      .eq('survey_id', surveyId)
+    orderIndex = (count ?? 0)
+  }
+
+  const { data, error } = await supabase
+    .from('questions')
+    .insert({
+      survey_id: surveyId,
+      type,
+      text: text.trim(),
+      order_index: orderIndex,
+      required: required ?? true,
+      options: type === 'multiple_choice' ? options : null,
+    })
+    .select('id, survey_id, type, text, options, order_index, required, created_at')
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}


### PR DESCRIPTION
## Summary

Adds question management endpoints for the survey builder.

## Routes
- `POST /api/surveys/[id]/questions` — add question to survey
- `PUT /api/questions/[id]` — update question fields (type, text, order, required, options)
- `DELETE /api/questions/[id]` — remove question
- `PUT /api/surveys/[id]/questions/reorder` — reorder via ordered `questionIds` array

## Key Behaviours
- 409 returned when survey status is `active` or `closed` (cannot modify questions)
- `multiple_choice` type requires at least 2 options; `options` is null for `likert`/`free_text`
- `reorder` sets `order_index = array_position` for each question ID
- Admin auth required on all routes via `requireAdmin()`

Closes #9